### PR TITLE
Add job name to diego-api health check

### DIFF
--- a/jobs/global-properties/templates/readiness-diego-api.sh
+++ b/jobs/global-properties/templates/readiness-diego-api.sh
@@ -5,8 +5,8 @@
 exec /usr/bin/curl                                       \
     --data ''                                            \
     --fail                                               \
-    --resolve 'diego-api:8889:127.0.0.1'                 \
+    --resolve 'diego-api-bbs:8889:127.0.0.1'             \
     --cert '/var/vcap/jobs/bbs/config/certs/server.crt'  \
     --key '/var/vcap/jobs/bbs/config/certs/server.key'   \
     --cacert '/var/vcap/jobs/bbs/config/certs/ca.crt'    \
-    'https://diego-api:8889/v1/ping'
+    'https://diego-api-bbs:8889/v1/ping'


### PR DESCRIPTION
Fissile uses job names in hostnames now