### PR TITLE
Allow the user of this release to provide the role manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ config/dev.yml
 dev_releases
 releases/*.tgz
 releases/**/*.tgz
-
+src/role-manifest.yml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+
+This release expects a `role-manifest.yml` to be copied to `./src`.
+
+This will be then be embedded in the secrets generator package.
+

--- a/packages/generate-secrets/packaging
+++ b/packages/generate-secrets/packaging
@@ -5,7 +5,7 @@ BIN_DIR=${BOSH_INSTALL_TARGET}/bin
 
 mkdir -p "${BIN_DIR}"
 
-cp -a "${BOSH_COMPILE_TARGET}/scf-config/role-manifest.yml" "${BOSH_INSTALL_TARGET}"
+cp -a "${BOSH_COMPILE_TARGET}/role-manifest.yml" "${BOSH_INSTALL_TARGET}"
 
 export GOROOT=$(readlink -nf /var/vcap/packages/golang1.10)
 export GOPATH=${BOSH_COMPILE_TARGET}

--- a/packages/generate-secrets/spec
+++ b/packages/generate-secrets/spec
@@ -4,4 +4,4 @@ dependencies:
   - golang1.10
 files:
   - github.com/SUSE/scf-secret-generator/**/*
-  - scf-config/*
+  - role-manifest.yml

--- a/src/scf-config
+++ b/src/scf-config
@@ -1,1 +1,0 @@
-../../../container-host-files/etc/scf/config


### PR DESCRIPTION
Makes things work for other projects that use fissile but don't have the same directory structure.