### PR TITLE
Merge master to develop

### DIFF
--- a/jobs/global-properties/templates/readiness-diego-api.sh
+++ b/jobs/global-properties/templates/readiness-diego-api.sh
@@ -5,8 +5,8 @@
 exec /usr/bin/curl                                       \
     --data ''                                            \
     --fail                                               \
-    --resolve 'diego-api:8889:127.0.0.1'                 \
+    --resolve 'diego-api-bbs:8889:127.0.0.1'             \
     --cert '/var/vcap/jobs/bbs/config/certs/server.crt'  \
     --key '/var/vcap/jobs/bbs/config/certs/server.key'   \
     --cacert '/var/vcap/jobs/bbs/config/certs/ca.crt'    \
-    'https://diego-api:8889/v1/ping'
+    'https://diego-api-bbs:8889/v1/ping'


### PR DESCRIPTION
Screwed up merging #12 (which was made against `master` instead of `develop`), so we need to do an additional merge.