### PR TITLE
Switch from Go 1.10 to 1.11.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -7,10 +7,10 @@ cli/cf-cli_6.33.1_linux_x86-64.tgz:
   object_id: cf-cli_6.33.1_linux_x86-64.tgz
   sha: 36d599d1e540c94f31740f6fac49adbf032a22a3
   size: 6223742
-golang/go1.10.linux-amd64.tar.gz:
-  size: 119905205
-  object_id: go1.10.linux-amd64.tar.gz
-  sha: 693e2dfd99ef2d608b41c450efd9d277bf2a7f2f
+golang/go1.11.1.linux-amd64.tar.gz:
+  size: 127205934
+  object_id: go1.11.1.linux-amd64.tar.gz
+  sha: 6446c7d8ef096c5ca6088ec87b46bf4c120f62b0
 ruby-2.3/bundler-1.11.2.gem:
   object_id: bundler-1.11.2.gem
   sha: 8eb956dec72da753d3d2a2126c78508b17af434e

--- a/packages/generate-secrets/packaging
+++ b/packages/generate-secrets/packaging
@@ -7,7 +7,7 @@ mkdir -p "${BIN_DIR}"
 
 cp -a "${BOSH_COMPILE_TARGET}/role-manifest.yml" "${BOSH_INSTALL_TARGET}"
 
-export GOROOT=$(readlink -nf /var/vcap/packages/golang1.10)
+export GOROOT=$(readlink -nf /var/vcap/packages/golang1.11.1)
 export GOPATH=${BOSH_COMPILE_TARGET}
 export PATH=$GOROOT/bin:$PATH
 

--- a/packages/generate-secrets/spec
+++ b/packages/generate-secrets/spec
@@ -1,7 +1,8 @@
 ---
 name: generate-secrets
 dependencies:
-  - golang1.10
+- golang1.11.1
+
 files:
-  - github.com/SUSE/scf-secret-generator/**/*
-  - role-manifest.yml
+- github.com/SUSE/scf-secret-generator/**/*
+- role-manifest.yml

--- a/packages/golang1.10/packaging
+++ b/packages/golang1.10/packaging
@@ -1,4 +1,0 @@
-set -e
-
-tar xzf golang/go1.10.linux-amd64.tar.gz
-cp -R go/* ${BOSH_INSTALL_TARGET}

--- a/packages/golang1.10/spec
+++ b/packages/golang1.10/spec
@@ -1,7 +1,0 @@
----
-name: golang1.10
-
-dependencies: []
-
-files:
-    - golang/go1.10.linux-amd64.tar.gz

--- a/packages/golang1.11.1/packaging
+++ b/packages/golang1.11.1/packaging
@@ -1,0 +1,4 @@
+set -e
+
+tar xzf golang/go1.11.1.linux-amd64.tar.gz
+cp -R go/* ${BOSH_INSTALL_TARGET}

--- a/packages/golang1.11.1/spec
+++ b/packages/golang1.11.1/spec
@@ -1,0 +1,7 @@
+---
+name: golang1.11.1
+
+dependencies: []
+
+files:
+- golang/go1.11.1.linux-amd64.tar.gz


### PR DESCRIPTION
Using Kubernetes from Docker for Mac I ran into this error with the scf-secrets-generator:

2018/10/30 14:20:06 Post https://10.96.0.1:443/api/v1/namespaces/my-nats/configmaps: tls: failed to parse certificate from server: x509: cannot parse dnsName "kubernetes.default.svc."

This seems to be a regression in Go 1.10: https://github.com/golang/go/issues/23995

Everything works fine again with Go 1.11.1 (it should be fixed in 1.10.1, but I went straight to the latest release).