### PR TITLE
Bump secrets generator to add support for kube CSRs

### DIFF
--- a/jobs/generate-secrets/spec
+++ b/jobs/generate-secrets/spec
@@ -10,6 +10,8 @@ templates:
   run.erb: bin/run
 
 properties:
+  scf.secrets.auto_approval:
+    description: "Attempt to auto-approve kube certificate signing requests."
   scf.secrets.domain:
     description: "Base domain of the cluster."
   scf.secrets.namespace:
@@ -17,6 +19,8 @@ properties:
   scf.secrets.cluster_domain:
     description: "Kubernetes cluster domain."
     default: cluster.local
+  scf.secrets.env:
+    description: A list of key=value pairs for template expansion.
   scf.secrets.name:
     description: "Secrets generation name."
   scf.secrets.generation:

--- a/jobs/generate-secrets/templates/run.erb
+++ b/jobs/generate-secrets/templates/run.erb
@@ -14,6 +14,7 @@ end
 %>
 
 scf-secret-generator \
+    -autoApproval="<%= p('scf.secrets.auto_approval') %>" \
     -certExpiration "<%= p('scf.secrets.cert_expiration') %>" \
     -clusterDomain "<%= p('scf.secrets.cluster_domain') %>" \
     -domain "<%= p('scf.secrets.domain') %>" \
@@ -21,4 +22,6 @@ scf-secret-generator \
     -namespace "<%= p('scf.secrets.namespace') %>" \
     -secretsName "<%= p('scf.secrets.name') %>" \
     -secretsGeneration "<%= p('scf.secrets.generation') %>" \
+<% p('scf.secrets.env', []).each do |var| %>    -set <%= var %> \
+<% end %>    \
     "<%= p('scf.manifest_path') %>"


### PR DESCRIPTION
Also adds two new properties for this: `scf.secrets.auto_approval` and `scf.secrets.env`.

[jsc#CAP-587]