### PR TITLE
Compatibility Fix for MySQL < 5.7.6

### DIFF
--- a/src/database-seeder/main.go
+++ b/src/database-seeder/main.go
@@ -35,26 +35,8 @@ func mysqlCreator(db *sql.DB, seedConfig SeedConfig) (err error) {
 		return err
 	}
 
-	// Create the user, or set the password if it already exists
-	result, err := exec("CREATE USER IF NOT EXISTS `%s` IDENTIFIED BY '%s'",
-		seedConfig.Username, seedConfig.Password)
-	if err != nil {
-		return err
-	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if rows < 1 {
-		_, err := exec("ALTER USER `%s` IDENTIFIED BY '%s'",
-			seedConfig.Username, seedConfig.Password)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Grant privileges
-	_, err = exec("GRANT ALL ON `%s`.* TO `%s`@`%%`", seedConfig.Name, seedConfig.Username)
+	// Grant privileges (implicitly creates or updates credentials as needed)
+	_, err = exec("GRANT ALL ON `%s`.* TO `%s`@`%%` IDENTIFIED BY '%s'", seedConfig.Name, seedConfig.Username, seedConfig.Password)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This sacrifices compatibility with MySQL > 8.0 (which does not support `IDENTIFIED BY` in a `GRANT` statement), to gain compatibility with MySQL < 5.7.6 (which do not support `IF NOT EXISTS` in a `CREATE USER` statement).

Syntax tested against:
 - MySQL 5.6.10a (valid)
 - MySQL 8.0.18 (invalid)
 - MariaDB 10.4.10 (valid)